### PR TITLE
Restructure nav to clarify audiences

### DIFF
--- a/master_middleman/source/subnavs/scdf_k8s_1_1_subnav.erb
+++ b/master_middleman/source/subnavs/scdf_k8s_1_1_subnav.erb
@@ -10,72 +10,72 @@
       <a href="/scdf-k8s/1-1/release-notes.html">Release Notes</a>
     </li>
     <li class="has_submenu">
-      <span>Preparation</span>
+      <span>Operator Guide</span>
       <ul>
-        <li>
-          <a href="/scdf-k8s/1-1/preparing-to-install-scdf-for-kubernetes.html">Preparing to Install</a>
+        <li class="has_submenu">
+          <span>Preparation</span>
+          <ul>
+            <li>
+              <a href="/scdf-k8s/1-1/preparing-to-install-scdf-for-kubernetes.html">Preparing to Install</a>
+            </li>
+            <li>
+              <a href="/scdf-k8s/1-1/installing-command-line-tools.html">Installing Command-Line Tools</a>
+            </li>
+          </ul>
         </li>
-        <li>
-          <a href="/scdf-k8s/1-1/installing-command-line-tools.html">Installing Command-Line Tools</a>
+        <li class="has_submenu">
+          <span>Configuration</span>
+          <ul>
+            <li>
+              <a href="/scdf-k8s/1-1/configuring-installation-values.html">Configuring Installation Values</a>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <a href="/scdf-k8s/1-1/configuring-monitoring.html">Configuring Monitoring</a>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <a href="/scdf-k8s/1-1/configuring-multi-platform.html">Configuring Multiple Platforms Support</a>
+            </li>
+          </ul>
+        </li>
+        <li class="has_submenu">
+          <span>Installation</span>
+          <ul>
+            <li>
+              <a href="/scdf-k8s/1-1/installing-scdf-for-kubernetes.html">Installing Spring Cloud Data Flow for Kubernetes</a>
+            </li>
+          </ul>
+        </li>
+        <li class="has_submenu">
+          <span>Upgrading</span>
+          <ul>
+            <li>
+              <a href="/scdf-k8s/1-1/updating-scdf-for-kubernetes.html">Upgrading</a>
+            </li>
+          </ul>
         </li>
       </ul>
     </li>
     <li class="has_submenu">
-      <span>Configuration</span>
+      <span>Developer Guide</span>
       <ul>
-        <li>
-          <a href="/scdf-k8s/1-1/configuring-installation-values.html">Configuring Installation Values</a>
+        <li class="has_submenu">
+          <span>Getting Started</span>
+          <ul>
+            <li>
+              <a href="/scdf-k8s/1-1/connecting-scdf-for-kubernetes.html">Connecting to Spring Cloud Data Flow for Kubernetes</a>
+            </li>
+            <li>
+              <a href="/scdf-k8s/1-1/getting-started-pipeline.html">Creating a Data Pipeline</a>
+            </li>
+          </ul>
         </li>
-      </ul>
-      <ul>
-        <li>
-          <a href="/scdf-k8s/1-1/configuring-monitoring.html">Configuring Monitoring</a>
-        </li>
-      </ul>
-      <ul>
-        <li>
-          <a href="/scdf-k8s/1-1/configuring-multi-platform.html">Configuring Multiple Platforms Support</a>
-        </li>
-      </ul>
-    </li>
-    <li class="has_submenu">
-      <span>Installation</span>
-      <ul>
-        <li>
-          <a href="/scdf-k8s/1-1/installing-scdf-for-kubernetes.html">Installing Spring Cloud Data Flow for Kubernetes</a>
-        </li>
-      </ul>
-    </li>
-    <li class="has_submenu">
-      <span>Getting Started</span>
-      <ul>
-        <li>
-          <a href="/scdf-k8s/1-1/connecting-scdf-for-kubernetes.html">Connecting to Spring Cloud Data Flow for Kubernetes</a>
-        </li>
-        <li>
-          <a href="/scdf-k8s/1-1/getting-started-pipeline.html">Creating a Data Pipeline</a>
-        </li>
-      </ul>
-    </li>
-    <li class="has_submenu">
-      <span>Multi-IO Stream Support</span>
-      <ul>
         <li>
           <a href="/scdf-k8s/1-1/multi-io-support.html">Multi-IO Stream Support</a>
         </li>
-      </ul>
-    </li>
-    <li class="has_submenu">
-      <span>Upgrading</span>
-      <ul>
-        <li>
-          <a href="/scdf-k8s/1-1/updating-scdf-for-kubernetes.html">Upgrading</a>
-        </li>
-      </ul>
-    </li>
-    <li class="has_submenu">
-      <span>Relocating Apps</span>
-      <ul>
         <li>
           <a href="/scdf-k8s/1-1/relocating-ootb-apps.html">Relocating Stream and Task Applications</a>
         </li>


### PR DESCRIPTION
This edits our nav structure to introduce an "Operator Guide" section and a "Developer Guide" section. The "Overview" and "Release Notes" topics are currently still top-level.

I am open to moving topics to different sections from what I've done here, but I really do think that it would be good to make this change in general. It could help guide users to the relevant topic(s) when they read the documentation and give them a nicer experience.